### PR TITLE
Enable referenceablebehavior on lists and memberships.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
     - cp buildout/* .
     - mkdir -p buildout-cache/eggs
     - mkdir -p buildout-cache/downloads
-    - python bootstrap.py -c travis.cfg
+    - python bootstrap.py -c travis.cfg --setuptools-version 7.0 --version 2.2.3
     - bin/buildout -N -t 3 -c travis.cfg
 
 script: bin/coverage run bin/test -s seantis.translators

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,7 +5,8 @@ Changelog
 0.4 (unreleased)
 ~~~~~~~~~~~~~~~~
 
-Nothing yet.
+- Enable referenceablebehavior on lists and memberships.
+  [jone]
 
 0.3 (2015-01-09)
 ~~~~~~~~~~~~~~~~

--- a/seantis/translators/profiles/default/metadata.xml
+++ b/seantis/translators/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>1002</version>
+    <version>1003</version>
     <dependencies>
         <dependency>profile-plone.app.dexterity:default</dependency>
         <dependency>profile-seantis.plonetools:default</dependency>

--- a/seantis/translators/profiles/default/types/seantis.translators.translator.xml
+++ b/seantis/translators/profiles/default/types/seantis.translators.translator.xml
@@ -23,6 +23,7 @@
   <property name="behaviors">
     <element value="seantis.people.interfaces.INameFromPerson" />
     <element value="seantis.people.interfaces.IPerson" />
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
   </property>
 
 </object>

--- a/seantis/translators/upgrades.py
+++ b/seantis/translators/upgrades.py
@@ -1,3 +1,4 @@
+from plone import api
 from seantis.people.upgrades import upgrade_portal_type
 
 
@@ -5,3 +6,18 @@ def upgrade_translators_type_info(context):
     upgrade_portal_type(
         'seantis.translators.translator', 'seantis.translators', 'default'
     )
+
+
+def enable_referenceablebehavior(context):
+    catalog = api.portal.get_tool('portal_catalog')
+    uid_catalog = api.portal.get_tool('uid_catalog')
+    types = api.portal.get_tool('portal_types')
+    portal = api.portal.get()
+
+    type_name = 'seantis.translators.translator'
+    types[type_name].behaviors += (
+        'plone.app.referenceablebehavior.referenceable.IReferenceable',)
+
+    for brain in catalog.unrestrictedSearchResults(portal_type=type_name):
+        obj = portal.unrestrictedTraverse(brain.getPath())
+        uid_catalog.catalog_object(obj, brain.getPath())

--- a/seantis/translators/upgrades.zcml
+++ b/seantis/translators/upgrades.zcml
@@ -15,4 +15,12 @@
         profile="seantis.translators:default"
         handler=".upgrades.upgrade_translators_type_info"
     />
+
+    <genericsetup:upgradeStep
+        title="Enable referenceablebehavior."
+        source="1002" destination="1003"
+        profile="seantis.translators:default"
+        handler=".upgrades.enable_referenceablebehavior"
+    />
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     'Plone>=4.3',
     'plone.api',
     'plone.app.dexterity [grok]',
+    'plone.app.referenceablebehavior',
     'five.grok',
     'seantis.plonetools',
     'seantis.people>=0.21'


### PR DESCRIPTION
The referenceablebehavior allows to add references from Archetypes objects to Dexterity objects.
It also adds the UIDs of the Dexterity objects to the UID catalog so that it can be queried for getting the object.

We need this for displaying recent changes on a dashboard of a remote Plone site using [ftw.bridge.client](https://github.com/4teamwork/ftw.bridge.client), which is based on UID lookups.